### PR TITLE
Set autonomous packet units

### DIFF
--- a/PlatformIO/TeensyDevelopment/lib/Constants/ControlConstants.hpp
+++ b/PlatformIO/TeensyDevelopment/lib/Constants/ControlConstants.hpp
@@ -28,6 +28,9 @@ namespace Constants {
     static constexpr float vescMinERPM = 0.0f;
     static constexpr float vescMaxERPM = 7'500.0f;
     static constexpr float vescERPMLimit = 1'500.0f;
+
+    static constexpr float steeringMaxDegrees = 37.8f;
+    static constexpr float steeringMaxTurns = 2.25f;
   };
 }
 

--- a/PlatformIO/TeensyDevelopment/lib/EVT_AutoMode/EVT_AutoMode.cpp
+++ b/PlatformIO/TeensyDevelopment/lib/EVT_AutoMode/EVT_AutoMode.cpp
@@ -6,6 +6,7 @@
 #include <EVT_Ethernet.hpp>
 #include <EVT_ODriver.hpp>
 
+#include "ControlConstants.hpp"
 #include "ModuleConstants.hpp"
 using namespace Constants;
 
@@ -23,7 +24,7 @@ bool brakeState = false;
 bool coasting = false;
 
 // Function to parse UDP data and update control variables
-// Expected format: "throttle,steering,emergency"
+// Expected format: "throttle_rpm,steering_degrees,emergency"
 void setControls(const std::string &udpData) {
   // Copy string to modifiable buffer
   char udpCopy[128];
@@ -39,7 +40,11 @@ void setControls(const std::string &udpData) {
         throttle = atof(token);
         break;
       case 1:
-        steering = atof(token);
+        steering = constrain(
+          atof(token),
+          -ControlConstants::steeringMaxDegrees,
+          ControlConstants::steeringMaxDegrees
+        );
         break;
       case 2:
         emergency = (atoi(token) != 0);
@@ -59,23 +64,38 @@ void setControls(const std::string &udpData) {
 
 void CtrlVesc() {
   if (emergency) {
-    ModuleConstants::vesc.updateAuto(0.0f, 20.0f);
+    throttleRpm = 0.0f;
+    brakeCurrent = 20.0f;
+    brakeState = true;
+    coasting = false;
+
+    ModuleConstants::vesc.updateAuto(0.0f, brakeCurrent);
     return;
   }
 
   if (throttle < 0.0f) {
-    brakeCurrent = (throttle * -1.0f) / 5; // brake current = throttle value divided by 5. if max throttle is -100 then max brake current is 20A for now. val can be changed
+    throttleRpm = 0.0f;
+    brakeCurrent = constrain(
+      (throttle * -1.0f) / ControlConstants::vescMaxERPM * ControlConstants::vescMaxBrake,
+      ControlConstants::vescMinBrake,
+      ControlConstants::vescMaxBrake
+    );
     brakeState = true;
+    coasting = false;
 
     ModuleConstants::vesc.updateAuto(0.0f, brakeCurrent);
     return;
   } else if (throttle == 0.0f) {
+    throttleRpm = 0.0f;
+    brakeCurrent = 0.0f;
+    brakeState = false;
     coasting = true;  
     ModuleConstants::vesc.updateAuto(0.0f, 0.0f);
     
     return;
   } else if (throttle > 0.0f) {
-    throttleRpm = (throttle / 100.0f) * 7500.0f; // map throttle 0-100 to 0 - maxRPM (7500 for old vescrpm,14800 new theoretical vesc)
+    throttleRpm = constrain(throttle, ControlConstants::vescMinERPM, ControlConstants::vescMaxERPM);
+    brakeCurrent = 0.0f;
     brakeState = false;
     coasting = false;
 
@@ -87,11 +107,11 @@ void CtrlVesc() {
 
 
 void CtrlOdrive() {
-  // Map steering (-100 to +100) to ODrive position range (-maxPos to +maxPos)
-  if (steering <-0.25f){
-    SteeringPos = (steering / 100.0f) * 2.25f; // map steering -100 to 0 to -maxPos to 0
+  // Map steering degrees to the existing ODrive turns command range.
+  if (steering < -0.25f) {
+    SteeringPos = (steering / ControlConstants::steeringMaxDegrees) * ControlConstants::steeringMaxTurns;
   } else if (steering > 0.25f) {
-    SteeringPos = (steering / 100.0f) * 2.25f; // map steering 0 to +100 to 0 to +maxPos
+    SteeringPos = (steering / ControlConstants::steeringMaxDegrees) * ControlConstants::steeringMaxTurns;
   } else {
     SteeringPos = 0.0f; // center position
   }
@@ -103,21 +123,21 @@ void CtrlOdrive() {
 void updateAutonomousMode() {
   std::string rawCommands = ModuleConstants::ethernet.receiveUDP();
 
+  if (!rawCommands.empty()) {
+    setControls(rawCommands);
+  }
+
+  CtrlVesc();
+  CtrlOdrive();
+
   Serial.print(" | Throttle(rpm): ");
   Serial.print(throttleRpm);
+  Serial.print(" steering(deg): ");
+  Serial.print(steering);
   Serial.print(" steering(turns): ");
   Serial.print(SteeringPos);
   Serial.print(" | Emergency: ");
   Serial.println(emergency ? "YES" : "NO");
   Serial.println(brakeState);
   Serial.println(coasting);
-
-
-  CtrlVesc();
-  CtrlOdrive();
-  ModuleConstants::ethernet.sendTelemetry();
-
-  if (!rawCommands.empty()) {
-    setControls(rawCommands);
-  }
 }

--- a/PlatformIO/TeensyDevelopment/lib/EVT_Ethernet/EVT_Ethernet.cpp
+++ b/PlatformIO/TeensyDevelopment/lib/EVT_Ethernet/EVT_Ethernet.cpp
@@ -149,15 +149,15 @@ namespace Signals {
       "%d,%s,%0.2f,%0.2f,%0.2f,%0.2f,%0.2f,%0.2f,%0.2f,%d,%d",
       ModuleConstants::stateMachine.checkError(),                                       // Emergency flag
       ModuleConstants::stateMachine.toString(ModuleConstants::stateMachine.getState()), // Current State
-      ModuleConstants::vesc.getState().erpmCommand,                                     // VESC ERPM target
-      ModuleConstants::odrive.getFeedback().pos,                                        // ODrive position
+      ModuleConstants::vesc.getState().erpmCommand,                                     // VESC RPM target
+      ModuleConstants::odrive.getSteeringDegrees(),                                     // Steering angle in degrees
       ModuleConstants::odrive.getVoltage(),                                             // ODrive voltage
       ModuleConstants::vesc.getVoltage(),                                               // VESC voltage
       ModuleConstants::odrive.getCurrent(),                                             // ODrive current
       ModuleConstants::vesc.getCurrent(),                                               // VESC current 
-      ModuleConstants::odrive.getTarget(),                                              // Target steering position
-      ModuleConstants::transmitter.getChannelValue(Signals::ChannelRC::RIGHT_X, false), // RC steering input position
-      ModuleConstants::transmitter.getChannelValue(Signals::ChannelRC::LEFT_Y, false)   // RC throttle input ERPM
+      ModuleConstants::odrive.getTargetDegrees(),                                       // Target steering in degrees
+      ModuleConstants::transmitter.getChannelValue(Signals::ChannelRC::RIGHT_X, false), // RC steering input
+      ModuleConstants::transmitter.getChannelValue(Signals::ChannelRC::LEFT_Y, false)   // RC throttle input
     );
 
     // Serial.println(telemetryBuffer);
@@ -170,9 +170,11 @@ namespace Signals {
 
   std::string EthernetEVT::receiveUDP() {
     if (udp.parsePacket() > 0) {
-      // Add a stop bit to the packet 
-      if (udp.read(autoBuffer, sizeof(autoBuffer - 1)) > 0) {
-        autoBuffer[udp.read(autoBuffer, sizeof(autoBuffer - 1))] = '\0';
+      int len = udp.read(autoBuffer, sizeof(autoBuffer) - 1);
+      if (len > 0) {
+        autoBuffer[len] = '\0';
+      } else {
+        autoBuffer[0] = '\0';
       }
 
       Serial.print("Received Packet: ");

--- a/PlatformIO/TeensyDevelopment/lib/EVT_ODriver/EVT_ODriver.cpp
+++ b/PlatformIO/TeensyDevelopment/lib/EVT_ODriver/EVT_ODriver.cpp
@@ -507,7 +507,8 @@ namespace MotorControls {
 
   void ODriver::updateAuto(float steering) {
     // Send position command (in turns) with a velocity limit
-    oDrive.trapezoidalMove(turnLimiter.calculate(steering));
+    currentTarget = turnLimiter.calculate(steering);
+    oDrive.trapezoidalMove(currentTarget);
   }
 
 
@@ -532,6 +533,42 @@ namespace MotorControls {
 
   float ODriver::getTarget() {
     return currentTarget;
+  }
+
+
+  float ODriver::getTargetDegrees() {
+    return turnsToSteeringDegrees(currentTarget);
+  }
+
+
+  ODriveFeedback ODriver::getFeedback() {
+    fb = oDrive.getFeedback();
+    currentPos = fb.pos;
+    return fb;
+  }
+
+
+  float ODriver::getSteeringDegrees() {
+    return turnsToSteeringDegrees(getFeedback().pos);
+  }
+
+
+  float ODriver::getVoltage() {
+    return oDrive.getParameterAsFloat("vbus_voltage");
+  }
+
+
+  float ODriver::getCurrent() {
+    return oDrive.getParameterAsFloat("ibus");
+  }
+
+
+  float ODriver::turnsToSteeringDegrees(float turns) {
+    return constrain(
+      (turns / ControlConstants::steeringMaxTurns) * ControlConstants::steeringMaxDegrees,
+      -ControlConstants::steeringMaxDegrees,
+      ControlConstants::steeringMaxDegrees
+    );
   }
 
 

--- a/PlatformIO/TeensyDevelopment/lib/EVT_ODriver/EVT_ODriver.hpp
+++ b/PlatformIO/TeensyDevelopment/lib/EVT_ODriver/EVT_ODriver.hpp
@@ -71,6 +71,8 @@ namespace MotorControls {
       
       unsigned long lastPrintTime = 0UL;       // Previous print time in miliseconds
       unsigned long initTime = 0UL;            // Start time for the initialization method 
+
+      float turnsToSteeringDegrees(float turns);
     public:
       /**
        * @brief Defines a new ODriver given a serial port
@@ -179,6 +181,46 @@ namespace MotorControls {
        * @return The current target position in turns 
        */
       float getTarget();
+
+
+      /**
+       * @brief Gets the current steering target in degrees
+       *
+       * @return Steering target in degrees
+       */
+      float getTargetDegrees();
+
+
+      /**
+       * @brief Gets the latest ODrive feedback
+       *
+       * @return ODriveFeedback containing position and velocity
+       */
+      ODriveFeedback getFeedback();
+
+
+      /**
+       * @brief Gets the current steering position in degrees
+       *
+       * @return Steering position in degrees
+       */
+      float getSteeringDegrees();
+
+
+      /**
+       * @brief Gets the ODrive bus voltage
+       *
+       * @return Voltage in volts
+       */
+      float getVoltage();
+
+
+      /**
+       * @brief Gets the ODrive bus current
+       *
+       * @return Current in amps
+       */
+      float getCurrent();
 
 
       /**

--- a/PlatformIO/TeensyDevelopment/lib/EVT_VescDriver/EVT_VescDriver.cpp
+++ b/PlatformIO/TeensyDevelopment/lib/EVT_VescDriver/EVT_VescDriver.cpp
@@ -60,12 +60,17 @@ namespace MotorControls {
 
 
   void VescDriver::updateAuto(float erpm, float brake) {
-    if (brake > 0.0f) {
-      vesc.setBrakeCurrent(brake);
+    targetValues.erpmCommand = constrain(erpm, ControlConstants::vescMinERPM, ControlConstants::vescMaxERPM);
+    targetValues.brakeCommand = constrain(brake, ControlConstants::vescMinBrake, ControlConstants::vescMaxBrake);
+
+    if (targetValues.brakeCommand > 0.0f) {
+      targetValues.erpmCommand = 0.0f;
+      vesc.setBrakeCurrent(targetValues.brakeCommand);
       return;
     }
 
-    vesc.setRPM(erpm);
+    targetValues.brakeCommand = 0.0f;
+    vesc.setRPM(targetValues.erpmCommand);
   }
 
 
@@ -140,5 +145,23 @@ namespace MotorControls {
 
   VescValues VescDriver::getState() {
     return targetValues;
+  }
+
+
+  float VescDriver::getVoltage() {
+    if (vesc.getVescValues()) {
+      return vesc.data.inpVoltage;
+    }
+
+    return 0.0f;
+  }
+
+
+  float VescDriver::getCurrent() {
+    if (vesc.getVescValues()) {
+      return vesc.data.avgInputCurrent;
+    }
+
+    return 0.0f;
   }
 }

--- a/PlatformIO/TeensyDevelopment/lib/EVT_VescDriver/EVT_VescDriver.hpp
+++ b/PlatformIO/TeensyDevelopment/lib/EVT_VescDriver/EVT_VescDriver.hpp
@@ -96,6 +96,22 @@ namespace MotorControls {
        * @return VescValues 
        */
       VescValues getState();
+
+
+      /**
+       * @brief Gets the latest measured VESC input voltage
+       *
+       * @return Input voltage in volts
+       */
+      float getVoltage();
+
+
+      /**
+       * @brief Gets the latest measured VESC input current
+       *
+       * @return Input current in amps
+       */
+      float getCurrent();
   };
 }
 

--- a/PlatformIO/TeensyDevelopment/src/main.cpp
+++ b/PlatformIO/TeensyDevelopment/src/main.cpp
@@ -76,6 +76,8 @@ void setup() {
 
     if (ModuleConstants::transmitter.getChannelValue(Signals::ChannelRC::SWG, Signals::ControlRC::mapSwitches)) {
       ModuleConstants::stateMachine.setState(Signals::States::IDLE);
+    } else {
+      updateAutonomousMode();
     }
   });
 


### PR DESCRIPTION
Review requested from integration lead before merge.

## Summary
- Treat AUTO throttle packet value as RPM
- Treat AUTO steering packet value as degrees
- Clamp steering to +/-37.8 degrees
- Convert steering degrees to the existing ODrive turns command range
- Ensure AUTO state calls the autonomous control path

## Packet Contract
Expected AUTO packet format:

```text
throttle_rpm,steering_degrees,emergency
```

## Verification
- `/home/evanh/Projects/ROB-Embedded-BigRobTestBench/.venv/bin/pio run` passes

## Review Notes
Please review before merge because BigRobTestBench is shared integration work.